### PR TITLE
Update to Leptos 0.8.2 and add missing rust-toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib", "rlib"]
 actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
 console_error_panic_hook = "0.1"
-http = { version = "1.0.0", optional = true }
-leptos = { version = "0.7.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-leptos_meta = { version = "0.7.0" }
-leptos_actix = { version = "0.7.0", optional = true }
-leptos_router = { version = "0.7.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+http = { version = "1.3.1", optional = true }
+leptos = { version = "0.8.2"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_meta = { version = "0.8.2" }
+leptos_actix = { version = "0.8.2", optional = true }
+leptos_router = { version = "0.8.2"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 wasm-bindgen = "=0.2.100"
 
 [features]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This PR updates the template to use **leptos 0.8.2** as well as the **http** dependency to version 1.3. It also adds the missing rust-toolchain file, which will be used in case the user wants to use the nightly features.